### PR TITLE
Barcode Update With Plate3_prime and Naming 

### DIFF
--- a/0.download_data/metadata/barcode_platemap.csv
+++ b/0.download_data/metadata/barcode_platemap.csv
@@ -1,4 +1,6 @@
 Assay_Plate_Barcode,Plate_Map_Name
-plate_1,platemap_NF1_plate1
-plate_2,platemap_NF1_plate2
-plate_3,platemap_NF1_plate3
+Plate_1_nf1_analysis,platemap_NF1_plate1
+Plate_2_nf1_analysis,platemap_NF1_plate2
+Plate_3_nf1_analysis,platemap_NF1_plate3
+Plate_3_prime_nf1_analysis,platemap_NF1_plate3
+Plate_4_nf1_analysis,platemap_NF1_plate4


### PR DESCRIPTION
## About 

This is a small PR that updates the `Assay_Plate_Barcode`  names in the barcode file. In addition, `Plate3_prime` has been added (matching with plate3_platemap) in the barcode file. Therefore, there should be 5 different plates with 4 platemaps. 