### PR TITLE
Update Plate 4 normalization to standardize to both WT and Null controls

### DIFF
--- a/3.processing_features/2.pycytominer_singlecell_pipelines.ipynb
+++ b/3.processing_features/2.pycytominer_singlecell_pipelines.ipynb
@@ -97,18 +97,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{   'Plate_3': {   'dest_path': 'data/converted_data/Plate_3.parquet',\n",
-      "                   'platemap_path': '/home/jenna/nf1_cellpainting_data/0.download_data/metadata/platemap_NF1_plate3.csv',\n",
-      "                   'source_path': '/home/jenna/nf1_cellpainting_data/2.cellprofiler_analysis/analysis_output/Plate_3/Plate_3_nf1_analysis.sqlite'},\n",
-      "    'Plate_3_prime': {   'dest_path': 'data/converted_data/Plate_3_prime.parquet',\n",
-      "                         'platemap_path': '/home/jenna/nf1_cellpainting_data/0.download_data/metadata/platemap_NF1_plate3.csv',\n",
-      "                         'source_path': '/home/jenna/nf1_cellpainting_data/2.cellprofiler_analysis/analysis_output/Plate_3_prime/Plate_3_prime_nf1_analysis.sqlite'},\n",
-      "    'Plate_4': {   'dest_path': 'data/converted_data/Plate_4.parquet',\n",
+      "{   'Plate_4': {   'dest_path': 'data/converted_data/Plate_4.parquet',\n",
       "                   'platemap_path': '/home/jenna/nf1_cellpainting_data/0.download_data/metadata/platemap_NF1_plate4.csv',\n",
-      "                   'source_path': '/home/jenna/nf1_cellpainting_data/2.cellprofiler_analysis/analysis_output/Plate_4/Plate_4_nf1_analysis.sqlite'},\n",
-      "    'Plate_5': {   'dest_path': 'data/converted_data/Plate_5.parquet',\n",
-      "                   'platemap_path': '/home/jenna/nf1_cellpainting_data/0.download_data/metadata/platemap_NF1_plate5.csv',\n",
-      "                   'source_path': '/home/jenna/nf1_cellpainting_data/2.cellprofiler_analysis/analysis_output/Plate_5/Plate_5_nf1_analysis.sqlite'}}\n"
+      "                   'source_path': '/home/jenna/nf1_cellpainting_data/2.cellprofiler_analysis/analysis_output/Plate_4/Plate_4_nf1_analysis.sqlite'}}\n"
      ]
     }
    ],
@@ -164,20 +155,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Now performing single-cell pycytominer pipeline for Plate_3\n",
-      "HET cells have been removed from Plate_3\n",
-      "Performing normalization for Plate_3 using samples parameter: all\n",
-      "(11286, 1165)\n",
-      "Now performing single-cell pycytominer pipeline for Plate_3_prime\n",
-      "HET cells have been removed from Plate_3_prime\n",
-      "Performing normalization for Plate_3_prime using samples parameter: all\n",
-      "(5506, 1140)\n",
       "Now performing single-cell pycytominer pipeline for Plate_4\n",
-      "Performing normalization for Plate_4 using samples parameter: Metadata_Concentration == 0.0 and Metadata_genotype == 'Null'\n",
-      "(7308, 1157)\n",
-      "Now performing single-cell pycytominer pipeline for Plate_5\n",
-      "Performing normalization for Plate_5 using samples parameter: all\n",
-      "(7759, 1147)\n"
+      "Performing normalization for Plate_4 using samples parameter: Metadata_Concentration == 0.0 and (Metadata_genotype == 'Null' or Metadata_genotype == 'WT')\n",
+      "(7308, 1157)\n"
      ]
     }
    ],
@@ -240,9 +220,10 @@
     "    # set default for samples to use in normalization\n",
     "    samples = \"all\"\n",
     "\n",
-    "    # Only for Plate 4, we want to normalize to no siRNA treatment Null cells (controls)\n",
+    "    # Only for Plate 4, we want to normalize to no siRNA treatment Null and WT cells (controls)\n",
     "    if plate == \"Plate_4\":\n",
-    "        samples = \"Metadata_Concentration == 0.0 and Metadata_genotype == 'Null'\"\n",
+    "        samples = \"Metadata_Concentration == 0.0 and (Metadata_genotype == 'Null' or Metadata_genotype == 'WT')\"\n",
+    "\n",
     "\n",
     "    print(f\"Performing normalization for {plate} using samples parameter: {samples}\")\n",
     "\n",

--- a/3.processing_features/data/single_cell_profiles/Plate_4_bulk_camerons_method.parquet
+++ b/3.processing_features/data/single_cell_profiles/Plate_4_bulk_camerons_method.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6bb5b832de4c473d3376188b1727dc01b2fe4951e7bddc78763b9f107819f4b5
-size 80755396
+oid sha256:ac0d778243daf880d19c92fbfdadd9cde5463e4ebcbc262aed2a46383d42b123
+size 80755426

--- a/3.processing_features/data/single_cell_profiles/Plate_4_sc_feature_selected.parquet
+++ b/3.processing_features/data/single_cell_profiles/Plate_4_sc_feature_selected.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cecef470ee15ec13733b057ad8cec23fbbb6a8a19b3e8c984722a29ef5df1617
-size 80796987
+oid sha256:463f3360a733583fa412349df45a46607deb5e36f5087bf0fe6cedbc25091886
+size 80797019

--- a/3.processing_features/data/single_cell_profiles/Plate_4_sc_normalized.parquet
+++ b/3.processing_features/data/single_cell_profiles/Plate_4_sc_normalized.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e073c0d2ac988d61c98a6dba8b01e52ba6ba4dcc913d02d3170a125a11eef45
-size 149203028
+oid sha256:5ec492527a9a8d9614210e9d5c8e4c670a8788a46fb3e9680ffd5442f410ef89
+size 149201986

--- a/3.processing_features/scripts/2.pycytominer_singlecell_pipelines.py
+++ b/3.processing_features/scripts/2.pycytominer_singlecell_pipelines.py
@@ -143,9 +143,10 @@ for plate, info in plate_info_dictionary.items():
     # set default for samples to use in normalization
     samples = "all"
 
-    # Only for Plate 4, we want to normalize to no siRNA treatment Null cells (controls)
+    # Only for Plate 4, we want to normalize to no siRNA treatment Null and WT cells (controls)
     if plate == "Plate_4":
-        samples = "Metadata_Concentration == 0.0 and Metadata_genotype == 'Null'"
+        samples = "Metadata_Concentration == 0.0 and (Metadata_genotype == 'Null' or Metadata_genotype == 'WT')"
+
 
     print(f"Performing normalization for {plate} using samples parameter: {samples}")
 


### PR DESCRIPTION
# Update Plate 4 normalization to standardize to both WT and Null controls

In this small PR, Plate 4 normalization was updated where the `samples` parameter now includes WT genotype and Null genotype at the 0 dose for siRNA. Processing steps were reran for Plate 4 only and added into the repo.